### PR TITLE
Intermission Pointers for Blackroom levels

### DIFF
--- a/res/in_epi1.txt
+++ b/res/in_epi1.txt
@@ -1,0 +1,92 @@
+Background wimap0
+Screensize 320 200
+Splat wisplat
+Pointer wiurh0 wiurh1
+
+Animation 224 104 11
+{
+	WIA00000
+	WIA00001
+	WIA00002
+}
+
+Animation 184 160 11
+{
+	WIA00100
+	WIA00101
+	WIA00102
+}
+
+Animation 112 136 11
+{
+	WIA00200
+	WIA00201
+	WIA00202
+}
+
+Animation 72 112 11
+{
+	WIA00300
+	WIA00301
+	WIA00302
+}
+
+Animation 88 96 11
+{
+	WIA00400
+	WIA00401
+	WIA00402
+}
+
+Animation 64 48 11
+{
+	WIA00500
+	WIA00501
+	WIA00502
+}
+
+Animation 192 40 11
+{
+	WIA00600
+	WIA00601
+	WIA00602
+}
+
+Animation 136 16 11
+{
+	WIA00700
+	WIA00701
+	WIA00702
+}
+
+Animation 80 16 11
+{
+	WIA00800
+	WIA00801
+	WIA00802
+}
+
+
+Animation 64 24 11
+{
+	WIA00900
+	WIA00901
+	WIA00902
+}
+
+
+Spots
+{
+    E1M1 185 164
+    E1M2 148 143
+    E1M3 69 122
+    E1M4 209 102
+    E1M4B 209 102
+    E1M5 116 89
+    E1M6 166 55
+    E1M7 71 56
+    E1M8 135 29
+    E1M8B 135 29
+    E1M9 71 24
+}
+ 

--- a/wadfusion.py
+++ b/wadfusion.py
@@ -478,6 +478,9 @@ def copy_resources():
             continue
         elif src_file == 'textures.masterlevelsbonus' and not (get_wad_filename('doom') and get_wad_filename('doom2') and (get_wad_filename('attack') or get_wad_filename('masterlevels')) and get_wad_filename('mines') and d1_wad.graphics.get(ULTIMATE_DOOM_ONLY_LUMP, None)):
             continue
+        # don't copy modified intermission script if alternate levels aren't present
+        elif src_file == 'in_epi1.txt' and not (get_wad_filename('e1m4b') or get_wad_filename('e1m8b')):
+            continue
         logg('Copying %s' % src_file)
         copyfile(RES_DIR + src_file, DEST_DIR + src_file)
 

--- a/wadfusion.py
+++ b/wadfusion.py
@@ -478,9 +478,6 @@ def copy_resources():
             continue
         elif src_file == 'textures.masterlevelsbonus' and not (get_wad_filename('doom') and get_wad_filename('doom2') and (get_wad_filename('attack') or get_wad_filename('masterlevels')) and get_wad_filename('mines') and d1_wad.graphics.get(ULTIMATE_DOOM_ONLY_LUMP, None)):
             continue
-        # don't copy modified intermission script if alternate levels aren't present
-        elif src_file == 'in_epi1.txt' and not (get_wad_filename('e1m4b') or get_wad_filename('e1m8b')):
-            continue
         logg('Copying %s' % src_file)
         copyfile(RES_DIR + src_file, DEST_DIR + src_file)
 

--- a/wadfusion_data.py
+++ b/wadfusion_data.py
@@ -113,7 +113,7 @@ RES_FILES = [
     'menudef.txt', 'cvarinfo.txt', 'zscript.zs',
     'zscript/wf_handler.zs', 'zscript/wf_music.zs',
     'zscript/wf_xbox.zs', 'zscript/wf_sbar.zs',
-    'wadfused.txt'
+    'wadfused.txt', 'in_epi1.txt'
 ]
 
 # files within pk3 dir that will be removed before a new run


### PR DESCRIPTION
For consideration, small cosmetic change.

Noticed that intermission pointers for the Blackroom alternate levels weren't displaying. Added a modified intermission script and wad check as a possible fix if this behavior was unintended.

BEFORE:
![BEFORE](https://github.com/user-attachments/assets/9bfce503-d900-41e6-bed3-422bc237347c)

AFTER:
![AFTER](https://github.com/user-attachments/assets/ad3b4dc1-6d6b-45ad-ab07-eb8a80a5ce0e)
