### PR TITLE
Add batch mode and JSON progress reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ WadFusion can be launched with the following command line arguments:
 - `-e`, `--extract-only` — Skip copying pre-authored lumps and only extract WADs (for developers).
 - `-b`, `--batch` — Run without confirmation or exit prompts. In batch mode,
   missing source WADs or IWADs produce a non-zero exit code.
+- `--progress-file PATH` — Write atomic JSON status updates to `PATH`, suitable
+  for a launcher or installer. Stages are `started`, `scanning`, `ready`,
+  `extracting`, `packaging`, `patching`, `done`, and `error`.
 
 ## Supported WADs
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ WadFusion can be launched with the following command line arguments:
   missing source WADs or IWADs produce a non-zero exit code.
 - `--progress-file PATH` — Write atomic JSON status updates to `PATH`, suitable
   for a launcher or installer. Stages are `started`, `scanning`, `ready`,
-  `extracting`, `packaging`, `patching`, `done`, and `error`.
+  `extracting`, `packaging`, `patching`, `done`, and `error`. Extraction updates
+  contain `current`, `total`, and `wad`; individual original Master Levels and
+  Rejects maps also include a `phase` of `masterlevels` or
+  `masterlevelsrejects`.
 
 ## Supported WADs
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ WadFusion can be launched with the following command line arguments:
 - `-p`, `--patch` — Patch an existing IPK3 without extracting WADs.
 - `-d`, `--deflate` — Use DEFLATE compression when generating the IPK3.
 - `-e`, `--extract-only` — Skip copying pre-authored lumps and only extract WADs (for developers).
+- `-b`, `--batch` — Run without confirmation or exit prompts. In batch mode,
+  missing source WADs or IWADs produce a non-zero exit code.
 
 ## Supported WADs
 

--- a/wadfusion.py
+++ b/wadfusion.py
@@ -1219,8 +1219,11 @@ def get_report_found():
 def clear_temp():
     # clear out temp dir from previous runs
     if path.exists(DEST_DIR):
-        rmtree(DEST_DIR)
-        logs('Removed temp directory from a previous run.\n')
+        try:
+            rmtree(DEST_DIR)
+            logs('Removed temp directory from a previous run.\n')
+        except OSError as error:
+            logg('WARNING: Could not remove temporary directory: %s' % error)
 
 def get_eps(wads_found):
     eps = []

--- a/wadfusion.py
+++ b/wadfusion.py
@@ -112,7 +112,17 @@ parser.add_argument('-w', '--wads', help='Search the specified directory path fo
 parser.add_argument('-p', '--patch', help='Patch an existing IPK3 without extracting WADs', action='store_true')
 parser.add_argument('-d', '--deflate', help='Use DEFLATE compression when generating the IPK3', action='store_true')
 parser.add_argument('-e', '--extract-only', help='Skip copying pre-authored lumps and only extract WADs (for developers)', action='store_true')
+parser.add_argument('-b', '--batch', help='Run without confirmation or exit prompts', action='store_true')
 args = parser.parse_args()
+
+def prompt_proceed(prompt):
+    if args.batch:
+        return 'y'
+    return input(prompt)
+
+def prompt_exit(prompt):
+    if not args.batch:
+        input(prompt)
 
 # data tables
 def declare_data():
@@ -1170,7 +1180,7 @@ def source_wads_dirs():
             logg('The specified WADs directory "' + path.realpath(j) + '" does not exist!')
             src_wad_dirs_errors += 1
             if src_wad_dirs_errors == src_wad_dirs_num:
-                input('Press Enter to exit.\n')
+                prompt_exit('Press Enter to exit.\n')
                 logfile.close()
                 return
         if not j.endswith('/'):
@@ -1268,11 +1278,11 @@ def pk3_compress():
 
 def pk3_patch():
     logs('Initialized in patch mode.')
-    i = input('Press Y and then Enter to patch an existing IPK3, anything else to cancel: ')
+    i = prompt_proceed('Press Y and then Enter to patch an existing IPK3, anything else to cancel: ')
     if i.lower() != 'y':
         logg('Canceled.')
         logfile.close()
-        return
+        return 0
     start_time = time.time()
     logg('\nProcessing %s...' % DEST_FILENAME)
     pk3 = ZipFile(DEST_FILENAME, 'r')
@@ -1288,9 +1298,10 @@ def pk3_patch():
     logg('Done!')
     if num_errors > 0:
         logg('%s errors found, see %s for details.' % (num_errors, LOG_FILENAME))
-    input('Press Enter to exit.\n')
+    prompt_exit('Press Enter to exit.\n')
     clear_temp()
     logfile.close()
+    return 0
 
 def main():
     global SRC_WAD_DIR, num_maps, num_eps
@@ -1318,24 +1329,23 @@ def main():
     declare_data()
     # patch an existing ipk3 if --patch argument is used
     if should_patch():
-        pk3_patch()
-        return
+        return pk3_patch()
     # add newgame maps only for present wads
     add_newgame()
     found = get_report_found()
     # bail if no wads in SRC_WAD_DIR
     if len(found) == 0:
         logg('No source WADs found!\nPlease place your WAD files into "%s".' % path.realpath(SRC_WAD_DIR[0]))
-        input('Press Enter to exit.\n')
+        prompt_exit('Press Enter to exit.\n')
         logfile.close()
-        return
+        return 1 if args.batch else 0
     logs('WADs found:\n' + ', '.join(found) + '\n')
     # bail if no iwads in SRC_WAD_DIR
     if not get_wad_filename('doom') and not get_wad_filename('doomu') and not get_wad_filename('doom2') and not get_wad_filename('tnt') and not get_wad_filename('plutonia'):
         logg('No source IWADs found!\nPlease place your IWAD files into "%s".' % path.realpath(SRC_WAD_DIR[0]))
-        input('Press Enter to exit.\n')
+        prompt_exit('Press Enter to exit.\n')
         logfile.close()
-        return
+        return 1 if args.batch else 0
     if args.wads and src_wad_dirs_errors > 0:
         logg('')
     logg('A new IPK3 will be generated with the following episodes:')
@@ -1350,11 +1360,11 @@ def main():
     # deduct iddm1 from the episode tally, since it won't show up in the menu
     if get_wad_filename('iddm1') and get_wad_filename('doom2'):
         num_eps -= 1
-    i = input('\nPress Y and then Enter to proceed, anything else to cancel: ')
+    i = prompt_proceed('\nPress Y and then Enter to proceed, anything else to cancel: ')
     if i.lower() != 'y':
         logg('Canceled.')
         logfile.close()
-        return
+        return 0
     start_time = time.time()
     logg('\nProcessing WADs...')
     # add additional lumps to the pre-defined lump lists
@@ -1375,9 +1385,10 @@ def main():
     logg('Done!')
     if num_errors > 0:
         logg('%s errors found, see %s for details.' % (num_errors, LOG_FILENAME))
-    input('Press Enter to exit.\n')
+    prompt_exit('Press Enter to exit.\n')
     clear_temp()
     logfile.close()
+    return 0
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/wadfusion.py
+++ b/wadfusion.py
@@ -1204,7 +1204,6 @@ def source_wads_dirs():
             src_wad_dirs_errors += 1
             if src_wad_dirs_errors == src_wad_dirs_num:
                 prompt_exit('Press Enter to exit.\n')
-                logfile.close()
                 return
         if not j.endswith('/'):
             j += '/'

--- a/wadfusion.py
+++ b/wadfusion.py
@@ -130,7 +130,17 @@ def write_progress(stage, **details):
         with open(temporary_path, 'w', encoding='utf-8') as progress_file:
             json.dump(progress, progress_file, sort_keys=True, separators=(',', ':'))
             progress_file.write('\n')
-        os.replace(temporary_path, progress_path)
+        # Inno Setup polls this file while WadFusion is running. On Windows its
+        # short-lived read handle can briefly prevent an atomic replacement.
+        # Retrying keeps the terminal "done" state from being lost.
+        for attempt in range(20):
+            try:
+                os.replace(temporary_path, progress_path)
+                return
+            except PermissionError:
+                if attempt == 19:
+                    return
+                time.sleep(0.05)
     except OSError:
         pass
 

--- a/wadfusion.py
+++ b/wadfusion.py
@@ -48,7 +48,7 @@
 ##------------------------------------------------------------------------------------------
 ##
 
-import platform, os, sys, time, fnmatch, argparse
+import platform, os, sys, time, fnmatch, argparse, json
 from shutil import copyfile, rmtree
 from zipfile import ZipFile, ZIP_DEFLATED, ZIP_STORED
 from os import path
@@ -113,7 +113,26 @@ parser.add_argument('-p', '--patch', help='Patch an existing IPK3 without extrac
 parser.add_argument('-d', '--deflate', help='Use DEFLATE compression when generating the IPK3', action='store_true')
 parser.add_argument('-e', '--extract-only', help='Skip copying pre-authored lumps and only extract WADs (for developers)', action='store_true')
 parser.add_argument('-b', '--batch', help='Run without confirmation or exit prompts', action='store_true')
+parser.add_argument('--progress-file', help='Write atomic JSON progress updates to PATH', metavar='PATH')
 args = parser.parse_args()
+
+def write_progress(stage, **details):
+    if not args.progress_file:
+        return
+    progress_path = path.abspath(args.progress_file)
+    progress_dir = path.dirname(progress_path)
+    progress = {'stage': stage, 'timestamp': time.time()}
+    progress.update(details)
+    try:
+        if progress_dir and not path.exists(progress_dir):
+            os.makedirs(progress_dir)
+        temporary_path = progress_path + '.tmp'
+        with open(temporary_path, 'w', encoding='utf-8') as progress_file:
+            json.dump(progress, progress_file, sort_keys=True)
+            progress_file.write('\n')
+        os.replace(temporary_path, progress_path)
+    except OSError:
+        pass
 
 def prompt_proceed(prompt):
     if args.batch:
@@ -948,11 +967,15 @@ def extract_lumps(wad_name):
             lump.to_file(lump_subdir + out_filename)
 
 def extract_iwads():
+    total_wads = len([wad_name for wad_name in WADS if wad_name and get_wad_filename(wad_name)])
+    current_wad = 0
     for iwad_name in WADS:
         wad_filename = get_wad_filename(iwad_name)
         if not wad_filename:
             logs('WAD %s not found' % iwad_name)
             continue
+        current_wad += 1
+        write_progress('extracting', current=current_wad, total=total_wads, wad=iwad_name)
         if iwad_name == 'masterlevels' and not get_wad_filename('doom2'):
             logg('  ERROR: Skipping masterlevels.wad as doom2.wad is not present', error=True)
             continue
@@ -1266,6 +1289,7 @@ def get_eps(wads_found):
     return eps
 
 def pk3_compress():
+    write_progress('packaging')
     logg('Compressing %s...' % DEST_FILENAME)
     pk3 = ZipFile(DEST_FILENAME, 'w', ZIP_DEFLATED if should_deflate() else ZIP_STORED, compresslevel=9)
     for dir_name, x, filenames in os.walk(DEST_DIR):
@@ -1277,6 +1301,7 @@ def pk3_compress():
     pk3.close()
 
 def pk3_patch():
+    write_progress('patching')
     logs('Initialized in patch mode.')
     i = prompt_proceed('Press Y and then Enter to patch an existing IPK3, anything else to cancel: ')
     if i.lower() != 'y':
@@ -1301,6 +1326,7 @@ def pk3_patch():
     prompt_exit('Press Enter to exit.\n')
     clear_temp()
     logfile.close()
+    write_progress('done', output=path.abspath(DEST_FILENAME))
     return 0
 
 def main():
@@ -1316,12 +1342,14 @@ def main():
         args_str += i + ' '
     if args_str != '':
         logs('Command line arguments used: ' + args_str + '\n')
+    write_progress('started')
     # clear out pk3 dir from previous runs
     clear_temp()
     title_line = 'WadFusion v%s' % VERSION
     logg(title_line + '\n' + '-' * len(title_line) + '\n')
     # source_wads/ directory stuff
     source_wads_dirs()
+    write_progress('scanning')
     # support for all the various filenames used by sigil releases
     declare_data_sigil()
     set_sigil_filenames()
@@ -1336,6 +1364,7 @@ def main():
     # bail if no wads in SRC_WAD_DIR
     if len(found) == 0:
         logg('No source WADs found!\nPlease place your WAD files into "%s".' % path.realpath(SRC_WAD_DIR[0]))
+        write_progress('error', message='No source WADs found')
         prompt_exit('Press Enter to exit.\n')
         logfile.close()
         return 1 if args.batch else 0
@@ -1343,6 +1372,7 @@ def main():
     # bail if no iwads in SRC_WAD_DIR
     if not get_wad_filename('doom') and not get_wad_filename('doomu') and not get_wad_filename('doom2') and not get_wad_filename('tnt') and not get_wad_filename('plutonia'):
         logg('No source IWADs found!\nPlease place your IWAD files into "%s".' % path.realpath(SRC_WAD_DIR[0]))
+        write_progress('error', message='No source IWADs found')
         prompt_exit('Press Enter to exit.\n')
         logfile.close()
         return 1 if args.batch else 0
@@ -1360,6 +1390,7 @@ def main():
     # deduct iddm1 from the episode tally, since it won't show up in the menu
     if get_wad_filename('iddm1') and get_wad_filename('doom2'):
         num_eps -= 1
+    write_progress('ready', wads=found)
     i = prompt_proceed('\nPress Y and then Enter to proceed, anything else to cancel: ')
     if i.lower() != 'y':
         logg('Canceled.')
@@ -1388,7 +1419,12 @@ def main():
     prompt_exit('Press Enter to exit.\n')
     clear_temp()
     logfile.close()
+    write_progress('done', output=path.abspath(DEST_FILENAME))
     return 0
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except Exception as error:
+        write_progress('error', message=str(error))
+        raise

--- a/wadfusion.py
+++ b/wadfusion.py
@@ -128,7 +128,7 @@ def write_progress(stage, **details):
             os.makedirs(progress_dir)
         temporary_path = progress_path + '.tmp'
         with open(temporary_path, 'w', encoding='utf-8') as progress_file:
-            json.dump(progress, progress_file, sort_keys=True)
+            json.dump(progress, progress_file, sort_keys=True, separators=(',', ':'))
             progress_file.write('\n')
         os.replace(temporary_path, progress_path)
     except OSError:

--- a/wadfusion.py
+++ b/wadfusion.py
@@ -728,7 +728,10 @@ def add_to_wad_lump_lists():
 
 def extract_master_levels():
     logs('Processing Master Levels...')
+    progress_total = len(MASTER_LEVELS_ORDER) + 1
     for i, wad_name in enumerate(MASTER_LEVELS_ORDER):
+        write_progress('extracting', current=i + 1, total=progress_total,
+                       wad='Master Levels: ' + wad_name, phase='masterlevels')
         in_wad = omg.WAD()
         wad_filename = get_wad_filename(wad_name)
         in_wad.from_file(wad_filename)
@@ -740,6 +743,8 @@ def extract_master_levels():
         map_name = in_wad.maps.find('*')[0]
         extract_map(in_wad, map_name, out_wad_filename)
     # save teeth map32 to map21
+    write_progress('extracting', current=progress_total, total=progress_total,
+                   wad='Master Levels: teeth MAP32', phase='masterlevels')
     wad_filename = get_wad_filename('teeth')
     out_wad_filename = DEST_DIR + 'maps/' + WAD_MAP_PREFIXES.get('masterlevels', '') + 'MAP21.wad'
     logs('  Extracting %s map32 to %s' % (wad_filename, out_wad_filename))
@@ -772,7 +777,13 @@ def copy_master_levels_doom1_music():
 def extract_master_levels_rejects():
     global num_maps
     logs('Processing Master Levels Rejects...')
+    progress_total = 22
+    progress_current = 0
     for i, wad_name in enumerate(MASTER_LEVELS_REJECTS_ORDER):
+        progress_current += 1
+        write_progress('extracting', current=progress_current, total=progress_total,
+                       wad='Master Levels Rejects: ' + wad_name,
+                       phase='masterlevelsrejects')
         in_wad = omg.WAD()
         wad_filename = get_wad_filename(wad_name)
         in_wad.from_file(wad_filename)
@@ -783,12 +794,18 @@ def extract_master_levels_rejects():
         map_name = in_wad.maps.find('*')[0]
         extract_map(in_wad, map_name, out_wad_filename)
     # copy E4M7 to use as John Anderson's 8th Canto
+    progress_current += 1
+    write_progress('extracting', current=progress_current, total=progress_total,
+                   wad='Master Levels Rejects: E4M7', phase='masterlevelsrejects')
     out_wad_filename = DEST_DIR + 'maps/' + 'ML_MAP35.wad'
     e4m7_filename = DEST_DIR + 'maps/' + 'E4M7.wad'
     logs('  Copying %s to %s' % (e4m7_filename, out_wad_filename))
     copyfile(e4m7_filename, out_wad_filename)
     num_maps += 1
     # copy UDTWiD E4M8 into dest dir and set its map lump name
+    progress_current += 1
+    write_progress('extracting', current=progress_current, total=progress_total,
+                   wad='Master Levels Rejects: UDTWiD E4M8', phase='masterlevelsrejects')
     in_wad = omg.WAD()
     wad_filename = get_wad_filename('udtwid')
     in_wad.from_file(wad_filename)
@@ -802,6 +819,10 @@ def extract_master_levels_rejects():
     wad_filename = get_wad_filename('caball')
     in_wad.from_file(wad_filename)
     for map_name in in_wad.maps.find('*'):
+        progress_current += 1
+        write_progress('extracting', current=progress_current, total=progress_total,
+                       wad='Master Levels Rejects: Caball ' + map_name,
+                       phase='masterlevelsrejects')
         out_wad_filename = DEST_DIR + 'maps/' + WAD_MAP_PREFIXES.get('masterlevels', '') + 'MAP'
         out_wad_filename += str(i + 37) + '.wad'
         logs('  Extracting %s map %s to %s' % (wad_filename, map_name, out_wad_filename))


### PR DESCRIPTION
Adds non-interactive integration support for installers and other callers.\n\n- --batch accepts the generation prompt and suppresses exit prompts.\n- --progress-file PATH writes atomic JSON stage updates (started, scanning, eady, extracting, packaging, patching, done, error).\n- Missing source WADs/IWADs return a non-zero exit code in batch mode.\n- Temporary-directory cleanup no longer turns an already generated IPK3 into a failure when Windows has a transient file lock.\n\nThe default interactive behavior is unchanged.