### PR TITLE
Add batch mode and JSON progress reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ If you've extracted the No Rest for the Living add-on episode for Doom 2 from Do
 
 In rare cases, you may need to uncheck the `source_wads/` folder's read-only status.
 
+Run `wadsmoosh.py --batch` to skip the confirmation and exit prompts. In batch
+mode, missing source WADs produce a non-zero exit code. To use a custom Master
+Levels order in batch mode, pass its filename alongside `--batch`.
+
 Advanced users can edit `wadsmoosh_data.py` to customize how and what WadSmoosh extracts. This file is Python code, read by the main program at runtime, so no recompile is required. You can also customize the ordering of the Master Levels by running WadSmoosh from the command line with a text file defining the ordering as an extra parameter. The ["Xaser ordering"](https://forum.zdoom.org/viewtopic.php?p=634600#p634600) is the default, but `masterlevels_order.txt` provides the mostly-alphabetical "PSN ordering", and more info on this customization option is included in comments at the top of that file. This is the only configuration option that WadSmoosh supports, and in general I'm opposed to adding more such options without turning WadSmoosh into a full-on GUI program.
 
 ## Supported WADs

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Run `wadsmoosh.py --batch` to skip the confirmation and exit prompts. In batch
 mode, missing source WADs produce a non-zero exit code. To use a custom Master
 Levels order in batch mode, pass its filename alongside `--batch`.
 
+Pass `--progress-file PATH` to write atomically updated JSON status to `PATH`.
+The stages are `started`, `scanning`, `ready`, `extracting`, `packaging`,
+`done`, and `error`.
+
 Advanced users can edit `wadsmoosh_data.py` to customize how and what WadSmoosh extracts. This file is Python code, read by the main program at runtime, so no recompile is required. You can also customize the ordering of the Master Levels by running WadSmoosh from the command line with a text file defining the ordering as an extra parameter. The ["Xaser ordering"](https://forum.zdoom.org/viewtopic.php?p=634600#p634600) is the default, but `masterlevels_order.txt` provides the mostly-alphabetical "PSN ordering", and more info on this customization option is included in comments at the top of that file. This is the only configuration option that WadSmoosh supports, and in general I'm opposed to adding more such options without turning WadSmoosh into a full-on GUI program.
 
 ## Supported WADs

--- a/wadsmoosh.py
+++ b/wadsmoosh.py
@@ -6,6 +6,18 @@ from zipfile import ZipFile, ZIP_STORED, ZIP_DEFLATED
 import omg
 
 VERSION_FILENAME = 'version'
+BATCH_MODE = '--batch' in sys.argv[1:]
+COMMAND_LINE_ARGS = [arg for arg in sys.argv[1:] if arg != '--batch']
+input_func = raw_input if sys.version_info.major < 3 else input
+
+def prompt_proceed(prompt):
+    if BATCH_MODE:
+        return 'y'
+    return input_func(prompt)
+
+def prompt_exit(prompt):
+    if not BATCH_MODE:
+        input_func(prompt)
 
 # if False, do a dry run with no actual file writing
 should_extract = True
@@ -73,8 +85,8 @@ def get_wad_filename(wad_name):
 
 def get_master_levels_map_order():
     order = []
-    if len(sys.argv) > 1:
-        order_file = ' '.join(sys.argv[1:])
+    if len(COMMAND_LINE_ARGS) > 0:
+        order_file = ' '.join(COMMAND_LINE_ARGS)
         if not os.path.exists(order_file):
             order_file = ML_ORDER_FILENAME
     else:
@@ -379,13 +391,12 @@ def main():
     title_line = 'WadSmoosh v%s' % version
     logg(title_line + '\n' + '-' * len(title_line))
     found = get_report_found()
-    input_func = raw_input if sys.version_info.major < 3 else input
     # bail if no wads in SRC_WAD_DIR
     if len(found) == 0:
         logg('No source WADs found!\nPlease place your WAD files into %s.' % os.path.realpath(SRC_WAD_DIR))
         logfile.close()
-        input_func('Press Enter to exit.\n')
-        return
+        prompt_exit('Press Enter to exit.\n')
+        return 1 if BATCH_MODE else 0
     # clear out pk3 dir from previous runs
     files_tidied = 0
     for dirname,extensions in TIDY_DIR_EXTENSIONS.items():
@@ -414,11 +425,11 @@ def main():
     for num_eps,ep_name in enumerate(get_eps(found)):
         print('- %s' % ep_name)
     num_eps += 1
-    i = input_func('Press Y and then Enter to proceed, anything else to cancel: ')
+    i = prompt_proceed('Press Y and then Enter to proceed, anything else to cancel: ')
     if i.lower() != 'y':
         logg('Canceled.')
         logfile.close()
-        return
+        return 0
     # make dirs if they don't exist
     if not os.path.exists(DEST_DIR):
         os.mkdir(DEST_DIR)
@@ -489,8 +500,9 @@ def main():
     logg('Generated %s (%.1f MB) with %s maps in %s episodes in %.2f seconds.' % (DEST_FILENAME, ipk3_size, num_maps, num_eps, elapsed_time))
     if num_errors > 0:
         logg('%s errors found, see %s for details.' % (num_errors, LOG_FILENAME))
-    input_func('Press Enter to exit.\n')
+    prompt_exit('Press Enter to exit.\n')
     logfile.close()
+    return 0
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/wadsmoosh.py
+++ b/wadsmoosh.py
@@ -1,13 +1,27 @@
 
-import os, sys, time
+import os, sys, time, json
 from shutil import copyfile
 from zipfile import ZipFile, ZIP_STORED, ZIP_DEFLATED
 
 import omg
 
 VERSION_FILENAME = 'version'
-BATCH_MODE = '--batch' in sys.argv[1:]
-COMMAND_LINE_ARGS = [arg for arg in sys.argv[1:] if arg != '--batch']
+BATCH_MODE = False
+PROGRESS_FILE = None
+COMMAND_LINE_ARGS = []
+argument_index = 0
+while argument_index < len(sys.argv[1:]):
+    argument = sys.argv[1:][argument_index]
+    if argument == '--batch':
+        BATCH_MODE = True
+    elif argument == '--progress-file' and argument_index + 1 < len(sys.argv[1:]):
+        argument_index += 1
+        PROGRESS_FILE = sys.argv[1:][argument_index]
+    elif argument.startswith('--progress-file='):
+        PROGRESS_FILE = argument.split('=', 1)[1]
+    else:
+        COMMAND_LINE_ARGS.append(argument)
+    argument_index += 1
 input_func = raw_input if sys.version_info.major < 3 else input
 
 def prompt_proceed(prompt):
@@ -18,6 +32,24 @@ def prompt_proceed(prompt):
 def prompt_exit(prompt):
     if not BATCH_MODE:
         input_func(prompt)
+
+def write_progress(stage, **details):
+    if not PROGRESS_FILE:
+        return
+    progress = {'stage': stage}
+    progress.update(details)
+    temporary_filename = PROGRESS_FILE + '.tmp'
+    try:
+        with open(temporary_filename, 'w') as progress_file:
+            json.dump(progress, progress_file, sort_keys=True, separators=(',', ':'))
+        if hasattr(os, 'replace'):
+            os.replace(temporary_filename, PROGRESS_FILE)
+        else:
+            if os.path.exists(PROGRESS_FILE):
+                os.remove(PROGRESS_FILE)
+            os.rename(temporary_filename, PROGRESS_FILE)
+    except OSError:
+        pass
 
 # if False, do a dry run with no actual file writing
 should_extract = True
@@ -387,14 +419,17 @@ def get_eps(wads_found):
 
 def main():
     start_time = time.time()
+    write_progress('started')
     version = open(VERSION_FILENAME).readlines()[0].strip()
     title_line = 'WadSmoosh v%s' % version
     logg(title_line + '\n' + '-' * len(title_line))
+    write_progress('scanning')
     found = get_report_found()
     # bail if no wads in SRC_WAD_DIR
     if len(found) == 0:
         logg('No source WADs found!\nPlease place your WAD files into %s.' % os.path.realpath(SRC_WAD_DIR))
         logfile.close()
+        write_progress('error', message='No source WADs found.')
         prompt_exit('Press Enter to exit.\n')
         return 1 if BATCH_MODE else 0
     # clear out pk3 dir from previous runs
@@ -425,10 +460,12 @@ def main():
     for num_eps,ep_name in enumerate(get_eps(found)):
         print('- %s' % ep_name)
     num_eps += 1
+    write_progress('ready', wads=found)
     i = prompt_proceed('Press Y and then Enter to proceed, anything else to cancel: ')
     if i.lower() != 'y':
         logg('Canceled.')
         logfile.close()
+        write_progress('error', message='Canceled by user.')
         return 0
     # make dirs if they don't exist
     if not os.path.exists(DEST_DIR):
@@ -447,11 +484,16 @@ def main():
         if not get_wad_filename('doom'):
             WAD_LUMP_LISTS['tnt'] += COMMON_LUMPS
     # extract lumps and maps from wads
+    wads_to_extract = [iwad_name for iwad_name in WADS if get_wad_filename(iwad_name)]
+    total_wads = len(wads_to_extract)
+    current_wad = 0
     for iwad_name in WADS:
         wad_filename = get_wad_filename(iwad_name)
         if not wad_filename:
             logg('WAD %s not found' % iwad_name)
             continue
+        current_wad += 1
+        write_progress('extracting', current=current_wad, total=total_wads, wad=iwad_name)
         if iwad_name == 'nerve' and not get_wad_filename('doom2'):
             logg('Skipping nerve.wad as doom2.wad is not present', error=True)
             continue
@@ -485,6 +527,7 @@ def main():
         logg('Copying %s' % genmidi_filename)
         copyfile(RES_DIR + genmidi_filename, DEST_DIR + genmidi_filename)
     # create pk3
+    write_progress('packaging')
     logg('Compressing %s...' % DEST_FILENAME)
     pk3 = ZipFile(DEST_FILENAME, 'w', ZIP_DEFLATED if should_deflate else ZIP_STORED)
     for dir_name, x, filenames in os.walk(DEST_DIR):
@@ -502,7 +545,12 @@ def main():
         logg('%s errors found, see %s for details.' % (num_errors, LOG_FILENAME))
     prompt_exit('Press Enter to exit.\n')
     logfile.close()
+    write_progress('done', output=os.path.abspath(DEST_FILENAME))
     return 0
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except Exception as error:
+        write_progress('error', message=str(error))
+        raise

--- a/wadsmoosh.py
+++ b/wadsmoosh.py
@@ -42,12 +42,19 @@ def write_progress(stage, **details):
     try:
         with open(temporary_filename, 'w') as progress_file:
             json.dump(progress, progress_file, sort_keys=True, separators=(',', ':'))
-        if hasattr(os, 'replace'):
-            os.replace(temporary_filename, PROGRESS_FILE)
-        else:
-            if os.path.exists(PROGRESS_FILE):
-                os.remove(PROGRESS_FILE)
-            os.rename(temporary_filename, PROGRESS_FILE)
+        for attempt in range(20):
+            try:
+                if hasattr(os, 'replace'):
+                    os.replace(temporary_filename, PROGRESS_FILE)
+                else:
+                    if os.path.exists(PROGRESS_FILE):
+                        os.remove(PROGRESS_FILE)
+                    os.rename(temporary_filename, PROGRESS_FILE)
+                return
+            except OSError:
+                if attempt == 19:
+                    return
+                time.sleep(0.05)
     except OSError:
         pass
 


### PR DESCRIPTION
Adds non-interactive integration support to the Wadsmoosh compatibility branch.\n\n- --batch accepts the generation prompt and suppresses exit prompts.\n- --progress-file PATH writes atomic JSON stage updates (started, scanning, eady, extracting, packaging, done, error).\n- Missing source WADs return a non-zero exit code in batch mode.\n\nThe default interactive behavior is unchanged.